### PR TITLE
only process delimiter if it is a custom query

### DIFF
--- a/src/Config/FindOptions.php
+++ b/src/Config/FindOptions.php
@@ -22,6 +22,7 @@ class FindOptions extends AbstractOptions implements PropertyPathConsumerInterfa
     public string $indexBy = '';
     public string $scalarProperty = '';
     public bool $allowDuplicates = false;
+    public bool $parseDelimiters = false;
     
     /**
      * @var array As per Doctrine, but with properties of children also allowed, eg.

--- a/src/Database/MySql/SqlSelectorMySql.php
+++ b/src/Database/MySql/SqlSelectorMySql.php
@@ -72,6 +72,7 @@ class SqlSelectorMySql implements SqlSelectorInterface
             throw new ObjectiphyException('SQL Selector has not been initialised. There is no mapping information!');
         }
         $this->query = $query;
+        $this->stringReplacer->parseDelimiters = $this->options->parseDelimiters;
         $this->stringReplacer->prepareReplacements($query, $this->options->mappingCollection);
 
         $sql = $this->getSelect();
@@ -92,7 +93,8 @@ class SqlSelectorMySql implements SqlSelectorInterface
         if ($this->disableMySqlCache) {
             $sql = str_replace('SELECT ', 'SELECT SQL_NO_CACHE ', $sql);
         }
-
+        $this->stringReplacer->resetParseDelimitersValue();
+        
         return $sql;
     }
 

--- a/src/Database/MySql/SqlSelectorMySql.php
+++ b/src/Database/MySql/SqlSelectorMySql.php
@@ -72,6 +72,7 @@ class SqlSelectorMySql implements SqlSelectorInterface
             throw new ObjectiphyException('SQL Selector has not been initialised. There is no mapping information!');
         }
         $this->query = $query;
+        $originalParseDelimeterValue = $this->stringReplacer->parseDelimiters;
         $this->stringReplacer->parseDelimiters = $this->options->parseDelimiters;
         $this->stringReplacer->prepareReplacements($query, $this->options->mappingCollection);
 
@@ -93,7 +94,8 @@ class SqlSelectorMySql implements SqlSelectorInterface
         if ($this->disableMySqlCache) {
             $sql = str_replace('SELECT ', 'SELECT SQL_NO_CACHE ', $sql);
         }
-        $this->stringReplacer->resetParseDelimitersValue();
+        // leave stringReplacer how we found it to prevent possible side effects
+        $this->stringReplacer->parseDelimiters = $originalParseDelimeterValue;
         
         return $sql;
     }

--- a/src/Database/SqlStringReplacer.php
+++ b/src/Database/SqlStringReplacer.php
@@ -57,6 +57,11 @@ class SqlStringReplacer
         $this->tokenSuffix = $tokenSuffix;
     }
 
+    public function resetParseDelimitersValue(): void
+    {
+        $this->parseDelimiters = true;
+    }
+    
     public function getDelimiter(string $type = 'database'): string
     {
         if (property_exists($this, $type . 'Delimiter')) {

--- a/src/Database/SqlStringReplacer.php
+++ b/src/Database/SqlStringReplacer.php
@@ -56,11 +56,6 @@ class SqlStringReplacer
         $this->tokenPrefix = $tokenPrefix;
         $this->tokenSuffix = $tokenSuffix;
     }
-
-    public function resetParseDelimitersValue(): void
-    {
-        $this->parseDelimiters = true;
-    }
     
     public function getDelimiter(string $type = 'database'): string
     {

--- a/src/Orm/ObjectFetcher.php
+++ b/src/Orm/ObjectFetcher.php
@@ -340,6 +340,7 @@ final class ObjectFetcher
             'multiple' => !($query->getLimit() == 1 || ($pkWithEquals && !$orsPresent)),
             'bindToEntities' => !$selectCount || $hasPureProperties,
             'scalarProperty' => $scalarProperty,
+            'parseDelimiters' => true,
         ]);
 
         return $findOptions;


### PR DESCRIPTION
With pre defined query methods in the repository (eg. findBy) don't process the delimiter as often inputted values get used and can cause issues with some stuff being treated as sql rather than text.

Limit the processing of delimiters to custom queries as then then the onus is on the developer to manage that input. 